### PR TITLE
Log timestamps and use unixgram name configured by SYSLOG_SOCKET env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,9 @@ func syslogRun(sysServer *syslog.Server, logs syslog.LogPartsChannel) {
 		if hostname, ok := logParts["hostname"]; ok && hostname != "" {
 			fmt.Printf("%s ", hostname)
 		}
+		if timestamp, ok := logParts["timestamp"]; ok && timestamp != "" {
+			fmt.Printf("%s ", timestamp)
+		}
 		if tag, ok := logParts["tag"]; ok && tag != "" {
 			fmt.Printf("%s ", tag)
 		}
@@ -102,7 +105,7 @@ func syslogCreate(socket string) (sysServer *syslog.Server, logs syslog.LogParts
 	sysServer = syslog.NewServer()
 	sysServer.SetFormat(syslog.Automatic)
 	sysServer.SetHandler(syslog.NewChannelHandler(logs))
-	sysServer.ListenUnixgram("/dev/log")
+	sysServer.ListenUnixgram(socket)
 
 	return
 }


### PR DESCRIPTION
If haproxy is logging things like xyz backend went up or down, it is not very helpful if the timestamp is not logged. 

SYSLOG_SOCKET environment variable is set to /dev/log which implies the name is configurable but then it ends up using hard coded /dev/log, so this uses the variable which is already being passed to the method but wasn't being used.